### PR TITLE
[failure of -z switch] run mkdirs() only if path non existing

### DIFF
--- a/src/main/java/org/jawk/backend/AwkCompilerImpl.java
+++ b/src/main/java/org/jawk/backend/AwkCompilerImpl.java
@@ -799,9 +799,11 @@ public class AwkCompilerImpl implements AwkCompiler {
 			}
 			String path = extractDirname(clsname, File.separator);
 			if (path != null) {
-				boolean dirCreated = new File(path).mkdirs();
-				if (!dirCreated) {
-					throw new IOException("Failed to create directory \"" + path + "\".");
+				File p = new File(path);
+				if (!p.exists()){
+					if (!p.mkdirs()) {
+						throw new IOException("Failed to create directory \"" + path + "\".");
+					}
 				}
 			}
 


### PR DESCRIPTION
run mkdirs() only if path does not exist, since mkdirs() returns true iff path is created (see [doc](https://docs.oracle.com/javase/7/docs/api/java/io/File.html#mkdirs%28%29)). Thus currently bumping into the IOEx if path already exists ... and then no AwkScript.class is generated.
